### PR TITLE
Subsetting and cmap fixes

### DIFF
--- a/byte_reader.go
+++ b/byte_reader.go
@@ -117,6 +117,12 @@ func (r *byteReader) readSlice(slice interface{}, length int) error {
 func (r byteReader) read(fields ...interface{}) error {
 	for _, f := range fields {
 		switch t := f.(type) {
+		case **f2dot14:
+			val, err := r.readF2dot14()
+			if err != nil {
+				return err
+			}
+			*t = &val
 		case *f2dot14:
 			val, err := r.readF2dot14()
 			if err != nil {

--- a/font.go
+++ b/font.go
@@ -525,6 +525,9 @@ func (f *font) TableInfo(table string) string {
 		for _, k := range f.cmap.subtableKeys {
 			subt := f.cmap.subtables[k]
 			b.WriteString(fmt.Sprintf("cmap subtable: %s: runes: %d\n", k, len(subt.runes)))
+			for i := range subt.charcodes {
+				b.WriteString(fmt.Sprintf("\t%d - Charcode %d (0x%X) - rune % X\n", i, subt.charcodes[i], subt.charcodes[i], subt.runes[i]))
+			}
 		}
 	case "loca":
 		if f.loca == nil {

--- a/table_glyf.go
+++ b/table_glyf.go
@@ -109,6 +109,8 @@ func (gd *glyphDescription) parse() error {
 	r := newByteReader(bytes.NewReader(gd.raw))
 	err := gd.parseHeader(r)
 	if err != nil {
+		logrus.Debugf("ERROR parsing header: %v", err)
+		logrus.Debugf("Raw data: %d bytes", len(gd.raw))
 		return err
 	}
 
@@ -252,6 +254,10 @@ func (glyf *glyfTable) GetComponents(gid GlyphIndex) ([]GlyphIndex, error) {
 	gdesc := glyf.descs[int(gid)]
 
 	if gdesc.header == nil {
+		if len(gdesc.raw) == 0 {
+			// No glyph data.
+			return nil, nil
+		}
 		err := gdesc.parse()
 		if err != nil {
 			logrus.Debugf("ERROR parsing header: %v", err)


### PR DESCRIPTION
- Enhanced `SubsetKeepIndices` to end by calling `SubsetFirst` keeping only the `maxNeededNum` glyph indices.
- Fixed a problem in `SubsetFirst` when creating cmaps that was causing errors displaying PDFs in Adobe with subset fonts.
- Fixed a problem with parsing glyf descriptions with no glyph data.
- Added a LookupRunes to lookup glyph indices by runes.  Based on common CMaps and a commonly used search order.